### PR TITLE
Keep '.java' extension when writing lol-ed file

### DIFF
--- a/deployment/src/main/java/io/quarkus/jokes/deployment/devui/JokesDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkus/jokes/deployment/devui/JokesDevUIProcessor.java
@@ -42,9 +42,10 @@ public class JokesDevUIProcessor {
                             input.put("path", input.get("path").replace(".java", ".joke"));
                             return t;
                         })
+                        // To update the file in place, remove the path converter
                         .pathConverter((t) -> {
                             Path original = (Path) t;
-                            return original.resolveSibling(original.getFileName().toString().replaceFirst("\\.java$", ".joke"));
+                            return original.resolveSibling("Joke" + original.getFileName().toString());
                         })
                         .display(Display.dialog)
                         .displayType(DisplayType.code),


### PR DESCRIPTION
So I honestly don't know if this is a good idea. I'm opening this for discussion, not merging. (And also so I don't lose my local change.)

When I demo the jokes extension, I like to show it replacing the transformed file in place, since that seems like a useful capability for an extension. Well, and also because the Java compiler then has a meltdown, which (a) usefully shows live reload and (b) is really funny. :) 

As a code sample, though, showing the path transformation is useful. I think both goals can be achieved by keeping the file extension as a '.java' one. Technically, the Java code should be edited to change the class name, but given the state of the Java file after the transformation, maybe the class name is the least of our worries. 